### PR TITLE
Update version of kind to use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,13 @@ jobs:
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
-    - uses: azure/setup-kubectl@v1
-    - uses: azure/setup-helm@v1
+    - uses: azure/setup-kubectl@v3.2
+    - uses: azure/setup-helm@v3.5
       with:
-        version: v3.8.0
+        version: v3.11.1
     - uses: engineerd/setup-kind@v0.5.0
+      with:
+        version: "v0.17.0" # Version of Kind to use
     - run: |
         helm repo add bitnami https://charts.bitnami.com/bitnami
         helm repo add stable https://charts.helm.sh/stable


### PR DESCRIPTION
This fixes CI being broken by updating the version of kind that is used. The default is `v0.11.1` and kind is on `v0.17.0`