### PR TITLE
fix: wait input not being read in

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,6 +45,7 @@ func NewFromInputs(action *githubactions.Action) (Config, error) {
 	c.Debug = parseBool(action, "debug")
 	c.DependencyUpdate = parseBool(action, "dependency-update")
 	c.DryRun = parseBool(action, "dry-run")
+	c.Wait = parseBool(action, "wait")
 	c.Force = parseBool(action, "force")
 	c.KubeContext = action.GetInput("kube-context")
 	c.Namespace = action.GetInput("namespace")
@@ -90,6 +91,10 @@ func (c Config) ToArgs() []string {
 
 	if c.DryRun {
 		args = append(args, "--dry-run")
+	}
+
+	if c.Wait {
+		args = append(args, "--wait")
 	}
 
 	if c.Force {

--- a/config_test.go
+++ b/config_test.go
@@ -50,3 +50,24 @@ func TestValuesFiles(t *testing.T) {
 		assert.Equal(t, []string{"upgrade", "--install", "--namespace", "mynamespace", "--values", "testdata/values.yaml", "--values", "testdata/values2.yaml", "myrelease", "mychart"}, args)
 	})
 }
+
+func TestOptionalInputs(t *testing.T) {
+	testEnv := map[string]string{
+		"INPUT_VALUES":       "testdata/values.yaml, testdata/values2.yaml",
+		"INPUT_CHART":        "mychart",
+		"INPUT_NAMESPACE":    "mynamespace",
+		"INPUT_RELEASE-NAME": "myrelease",
+		"INPUT_DRY-RUN":      "true",
+		"INPUT_ATOMIC":       "true",
+		"INPUT_WAIT":         "true",
+		"INPUT_DEBUG":        "true",
+	}
+
+	withEnv(t, testEnv, func() {
+		config, err := NewFromInputs(githubactions.New())
+		assert.NoError(t, err)
+
+		args := config.ToArgs()
+		assert.Equal(t, []string{"upgrade", "--install", "--atomic", "--debug", "--dry-run", "--wait", "--namespace", "mynamespace", "--values", "testdata/values.yaml", "--values", "testdata/values2.yaml", "myrelease", "mychart"}, args)
+	})
+}


### PR DESCRIPTION
currently the wait input exists as a Config struct field but is not used as an input/argument for the end helm command